### PR TITLE
fix: changed && to || in hasLocationPermission extension of context s…

### DIFF
--- a/app/src/main/java/com/muhammetkdr/weatherapp/common/extensions/ContextExtensions.kt
+++ b/app/src/main/java/com/muhammetkdr/weatherapp/common/extensions/ContextExtensions.kt
@@ -9,7 +9,7 @@ import androidx.core.content.ContextCompat
 fun Context.hasLocationPermission(): Boolean {
     return ContextCompat.checkSelfPermission(
         this, Manifest.permission.ACCESS_COARSE_LOCATION
-    ) == PackageManager.PERMISSION_GRANTED && ContextCompat.checkSelfPermission(
+    ) == PackageManager.PERMISSION_GRANTED || ContextCompat.checkSelfPermission(
         this, Manifest.permission.ACCESS_FINE_LOCATION
     ) == PackageManager.PERMISSION_GRANTED
 }


### PR DESCRIPTION
changed && to || in hasLocationPermission extension of context so that app can continue with only approximate location permission instead of requiring two permissions together